### PR TITLE
fix: Broken link on Assignment: Profiles, Positions and jQuery page #68

### DIFF
--- a/assn/res-position/index.php
+++ b/assn/res-position/index.php
@@ -44,7 +44,7 @@ You can explore a sample solution for this problem at
 <p>There are several resources you might find useful:
 <ul>
 <li>You might want to refer back to the resources for the 
-<a href="../../res-profile/index.php" target="_blank" rel="noopener noreferrer">
+<a href="../res-profile/index.php" target="_blank" rel="noopener noreferrer">
 previous assignment</a>.
 </li>
 <li>An article from Stack Overflow on


### PR DESCRIPTION
### Description
This PR fixes issue #68, a broken link on the **Assignment: Profiles, Positions and jQuery** page. The "previous assignment" link was using an incorrect relative path, causing a 404 error by trying to access the root directory instead of the sibling directory within the `/assn/` folder.

### Changes
*   Modified the `href` attribute in `assn/res-position/index.php`.
*   Changed path from `../../res-profile/index.php` to `../res-profile/index.php`.

### Related Issue
Closes #68